### PR TITLE
Add the new `String Array` type to `Select` Query Constraint

### DIFF
--- a/build/nodes/locales/en-US/firestore-in.json
+++ b/build/nodes/locales/en-US/firestore-in.json
@@ -62,6 +62,9 @@
       "in": "In",
       "not-in": "Not in",
       "array-contains-any": "Array contains any"
+    },
+    "validator": {
+      "invalid-string-array": "The value is not a valid string array"
     }
   },
   "validator": {

--- a/build/nodes/locales/en-US/firestore-in.json
+++ b/build/nodes/locales/en-US/firestore-in.json
@@ -63,6 +63,9 @@
       "not-in": "Not in",
       "array-contains-any": "Array contains any"
     },
+    "typedInput": {
+      "array": "string array"
+    },
     "validator": {
       "invalid-string-array": "The value is not a valid string array"
     }

--- a/build/nodes/locales/fr/firestore-in.json
+++ b/build/nodes/locales/fr/firestore-in.json
@@ -62,6 +62,9 @@
       "in": "Dans",
       "not-in": "Pas dans",
       "array-contains-any": "Contient un des"
+    },
+    "validator": {
+      "invalid-string-array": "La valeur n'est pas un tableau de chaînes valide"
     }
   },
   "validator": {

--- a/build/nodes/locales/fr/firestore-in.json
+++ b/build/nodes/locales/fr/firestore-in.json
@@ -63,6 +63,9 @@
       "not-in": "Pas dans",
       "array-contains-any": "Contient un des"
     },
+    "typedInput": {
+      "array": "tableau de chaînes"
+    },
     "validator": {
       "invalid-string-array": "La valeur n'est pas un tableau de chaînes valide"
     }

--- a/resources/array-brackets.svg
+++ b/resources/array-brackets.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg fill="#000000" width="800px" height="800px" viewBox="0 0 256 256" id="Flat" xmlns="http://www.w3.org/2000/svg">
+  <path d="M44,44V212H80a4,4,0,0,1,0,8H40a4.0002,4.0002,0,0,1-4-4V40a4.0002,4.0002,0,0,1,4-4H80a4,4,0,0,1,0,8Zm172-8H176a4,4,0,0,0,0,8h36V212H176a4,4,0,0,0,0,8h40a4.0002,4.0002,0,0,0,4-4V40A4.0002,4.0002,0,0,0,216,36Z"/>
+</svg>

--- a/resources/constraints.js
+++ b/resources/constraints.js
@@ -41,7 +41,7 @@ var FirestoreQueryConstraintsContainer = FirestoreQueryConstraintsContainer || (
 
 	const stringArrayFieldType = {
 		value: "array",
-		label: "String Array",
+		label: i18n("typedInput.array"),
 		icon: "resources/@gogovega/node-red-contrib-cloud-firestore/array-brackets.svg",
 		validate: isSelectValueValid,
 		expand: function () {

--- a/src/lib/types/firestore-config.ts
+++ b/src/lib/types/firestore-config.ts
@@ -64,6 +64,11 @@ interface OrderBy {
 
 interface Select {
 	value: string;
+
+	/**
+	 * The `array` type used in the editor is a minimal version of the `json` type that only accepts
+	 * an array of strings. That's why the `json` type is used here to convert the value.
+	 */
 	valueType: DynamicTypedInputType | "str" | "json";
 }
 


### PR DESCRIPTION
The `Select` Query Constraint now has a new `String Array` (`array`) type which replaces the overly generic `json` type:

<img width="457" alt="Capture d’écran 2024-08-14 à 18 17 01" src="https://github.com/user-attachments/assets/73ed4f8c-de0e-42ec-acbe-96070900bdef">