### PR TITLE
Allow multiple use of `orderBy` and `where` Query Constraints

### DIFF
--- a/build/nodes/locales/en-US/firestore-get.html
+++ b/build/nodes/locales/en-US/firestore-get.html
@@ -64,25 +64,25 @@
 		<li><code>limitToFirst</code><span class="property-type">number</span></li>
 		<li><code>limitToLast</code><span class="property-type">number</span></li>
 		<li><code>offset</code><span class="property-type">number</span></li>
-		<li><code>orderBy</code><span class="property-type">object</span></li>
+		<li><code>orderBy</code><span class="property-type">array</span></li>
 		<li><code>select</code><span class="property-type">string | string array</span></li>
 		<li><code>startAfter</code><span class="property-type">various</span></li>
 		<li><code>startAt</code><span class="property-type">various</span></li>
-		<li><code>where</code><span class="property-type">object</span></li>
+		<li><code>where</code><span class="property-type">array</span></li>
 	</ul>
 	<p>The <code>msg.constraints</code> will look like this:</p>
 	<pre>
 {
   "limitToFirst": 5,
-  "orderBy": {
+  "orderBy": [{
     "fieldPath": "some-path",
     "direction": "asc"
-  },
-  "where": {
+  }],
+  "where": [{
     "fieldPath": "some-path",
     "filter": ">",
     "value": 1
-  }
+  }]
 }</pre>
 	<p>
 		Click <a href="https://github.com/GogoVega/node-red-contrib-cloud-firestore/wiki/firestore-get">here</a>

--- a/build/nodes/locales/en-US/firestore-in.html
+++ b/build/nodes/locales/en-US/firestore-in.html
@@ -68,25 +68,25 @@
 		<li><code>limitToFirst</code><span class="property-type">number</span></li>
 		<li><code>limitToLast</code><span class="property-type">number</span></li>
 		<li><code>offset</code><span class="property-type">number</span></li>
-		<li><code>orderBy</code><span class="property-type">object</span></li>
+		<li><code>orderBy</code><span class="property-type">array</span></li>
 		<li><code>select</code><span class="property-type">string | string array</span></li>
 		<li><code>startAfter</code><span class="property-type">various</span></li>
 		<li><code>startAt</code><span class="property-type">various</span></li>
-		<li><code>where</code><span class="property-type">object</span></li>
+		<li><code>where</code><span class="property-type">array</span></li>
 	</ul>
 	<p>The <code>msg.constraints</code> will look like this:</p>
 	<pre>
 {
   "limitToFirst": 5,
-  "orderBy": {
+  "orderBy": [{
     "fieldPath": "some-path",
     "direction": "asc"
-  },
-  "where": {
+  }],
+  "where": [{
     "fieldPath": "some-path",
     "filter": ">",
     "value": 1
-  }
+  }]
 }</pre>
 	<p>
 		Click <a href="https://github.com/GogoVega/node-red-contrib-cloud-firestore/wiki/firestore-in">here</a>

--- a/build/nodes/locales/fr/firestore-get.html
+++ b/build/nodes/locales/fr/firestore-get.html
@@ -61,25 +61,25 @@
 		<li><code>limitToFirst</code><span class="property-type">nombre</span></li>
 		<li><code>limitToLast</code><span class="property-type">nombre</span></li>
 		<li><code>offset</code><span class="property-type">nombre</span></li>
-		<li><code>orderBy</code><span class="property-type">objet</span></li>
+		<li><code>orderBy</code><span class="property-type">tableau</span></li>
 		<li><code>select</code><span class="property-type">chaîne | tableau de chaînes</span></li>
 		<li><code>startAfter</code><span class="property-type">divers</span></li>
 		<li><code>startAt</code><span class="property-type">divers</span></li>
-		<li><code>where</code><span class="property-type">objet</span></li>
+		<li><code>where</code><span class="property-type">tableau</span></li>
 	</ul>
 	<p>Le <code>msg.constraints</code> ressemblera à ceci :</p>
 	<pre>
 {
   "limitToFirst": 5,
-  "orderBy": {
+  "orderBy": [{
     "fieldPath": "some-path",
     "direction": "asc"
-  },
-  "where": {
+  }],
+  "where": [{
     "fieldPath": "some-path",
     "filter": ">",
     "value": 1
-  }
+  }]
 }</pre>
 	<p>
 		Cliquer <a href="https://github.com/GogoVega/node-red-contrib-cloud-firestore/wiki/firestore-get">ici</a> 

--- a/build/nodes/locales/fr/firestore-in.html
+++ b/build/nodes/locales/fr/firestore-in.html
@@ -65,25 +65,25 @@
 		<li><code>limitToFirst</code><span class="property-type">nombre</span></li>
 		<li><code>limitToLast</code><span class="property-type">nombre</span></li>
 		<li><code>offset</code><span class="property-type">nombre</span></li>
-		<li><code>orderBy</code><span class="property-type">objet</span></li>
+		<li><code>orderBy</code><span class="property-type">tableau</span></li>
 		<li><code>select</code><span class="property-type">chaîne | tableau de chaînes</span></li>
 		<li><code>startAfter</code><span class="property-type">divers</span></li>
 		<li><code>startAt</code><span class="property-type">divers</span></li>
-		<li><code>where</code><span class="property-type">objet</span></li>
+		<li><code>where</code><span class="property-type">tableau</span></li>
 	</ul>
 	<p>Le <code>msg.constraints</code> ressemblera à ceci :</p>
 	<pre>
 {
   "limitToFirst": 5,
-  "orderBy": {
+  "orderBy": [{
     "fieldPath": "some-path",
     "direction": "asc"
-  },
-  "where": {
+  }],
+  "where": [{
     "fieldPath": "some-path",
     "filter": ">",
     "value": 1
-  }
+  }]
 }</pre>
 	<p>
 		Cliquer <a href="https://github.com/GogoVega/node-red-contrib-cloud-firestore/wiki/firestore-in">ici</a> 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@gogovega/firebase-config-node": "^0.1.0"
+        "@gogovega/firebase-config-node": "^0.1.1"
       },
       "devDependencies": {
         "@types/node-red": "^1.3.5",
@@ -162,9 +162,9 @@
       "license": "MIT"
     },
     "node_modules/@firebase/app": {
-      "version": "0.10.8",
-      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.10.8.tgz",
-      "integrity": "sha512-xSLmW0/RShcnUEXH7l+wC0AFWaUtty4tUFF2loIgbtXTRmra0UH/SqYDf/IcfreUninRrCsusNmvoTidGkXJPw==",
+      "version": "0.10.9",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.10.9.tgz",
+      "integrity": "sha512-AmGlPg/4SoDhwCdvVDeZsN5Yn+czYD/m/NAEOOCOhwn3Cz1xmEFKAKcyZKKahLrh5QPmge5Adyw+sk3cBTubBg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@firebase/component": "0.6.8",
@@ -187,9 +187,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/auth": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.7.6.tgz",
-      "integrity": "sha512-T+lA5xoug9CByGYkD5WkfTh2ujEYq/frGZPbk0H+fNU6fNl7nqg88KcsmzsC6Fsqbjm3LLEb/i6wJvF6NSNEig==",
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.7.7.tgz",
+      "integrity": "sha512-gMB0uRRNiIvYorEDLtIq1mc7x5D080EsoghTIph9xnbLqcQS3qRBREEC2o21nMEhviAeiGJMelRkKhAkkggjmA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@firebase/component": "0.6.8",
@@ -264,9 +264,9 @@
       }
     },
     "node_modules/@firebase/firestore": {
-      "version": "4.6.5",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.6.5.tgz",
-      "integrity": "sha512-0+Ascaht4qUzj4pCopMPWmoAujk8HKjwCpaNYOOjbYMZ65RVfZPsfZwwbWi/zWMXj6xvPsai5oBiErUUkrLwNw==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.7.0.tgz",
+      "integrity": "sha512-wGOp84P1qa1pfpdct6lckfyowTuvIlUDHoiRcN8dFDT4WnZDh0tZW1X77SMiBUVejK8xIRLBCK3yDTejlRVrUA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@firebase/component": "0.6.8",
@@ -310,15 +310,15 @@
       "license": "Apache-2.0"
     },
     "node_modules/@gogovega/firebase-config-node": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@gogovega/firebase-config-node/-/firebase-config-node-0.1.0.tgz",
-      "integrity": "sha512-en+5IqmQrEvwX7f80EDX63vWEpalEcO3RNJnPqiindnlrVqpDGBGO4Zp9uH0liXh9BbIr3ui3YoWEjkcGpPbJA==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@gogovega/firebase-config-node/-/firebase-config-node-0.1.1.tgz",
+      "integrity": "sha512-bTLi7Wpy1lguZEMxAOdWwBh1Mbsb5NYyb6vgIXenadJMQoMP0saaBjuyHi1A+ZZvCfPtjvRurB78dr/1CLPNkg==",
       "license": "MIT",
       "dependencies": {
-        "@firebase/app": "0.10.8",
-        "@firebase/auth": "1.7.6",
+        "@firebase/app": "0.10.9",
+        "@firebase/auth": "1.7.7",
         "@firebase/database": "1.0.7",
-        "@firebase/firestore": "4.6.5",
+        "@firebase/firestore": "4.7.0",
         "firebase-admin": "^12.3.1",
         "tiny-typed-emitter": "^2.1.0"
       },
@@ -7256,9 +7256,9 @@
       "integrity": "sha512-83rnH2nCvclWaPQQKvkJ2pdOjG4TZyEVuFDnlOF6KP08lDaaceVyw/W63mDuafQT+MKHCvXIPpE5uYWeM0rT4w=="
     },
     "@firebase/app": {
-      "version": "0.10.8",
-      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.10.8.tgz",
-      "integrity": "sha512-xSLmW0/RShcnUEXH7l+wC0AFWaUtty4tUFF2loIgbtXTRmra0UH/SqYDf/IcfreUninRrCsusNmvoTidGkXJPw==",
+      "version": "0.10.9",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.10.9.tgz",
+      "integrity": "sha512-AmGlPg/4SoDhwCdvVDeZsN5Yn+czYD/m/NAEOOCOhwn3Cz1xmEFKAKcyZKKahLrh5QPmge5Adyw+sk3cBTubBg==",
       "requires": {
         "@firebase/component": "0.6.8",
         "@firebase/logger": "0.4.2",
@@ -7278,9 +7278,9 @@
       "integrity": "sha512-oMEZ1TDlBz479lmABwWsWjzHwheQKiAgnuKxE0pz0IXCVx7/rtlkx1fQ6GfgK24WCrxDKMplZrT50Kh04iMbXQ=="
     },
     "@firebase/auth": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.7.6.tgz",
-      "integrity": "sha512-T+lA5xoug9CByGYkD5WkfTh2ujEYq/frGZPbk0H+fNU6fNl7nqg88KcsmzsC6Fsqbjm3LLEb/i6wJvF6NSNEig==",
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.7.7.tgz",
+      "integrity": "sha512-gMB0uRRNiIvYorEDLtIq1mc7x5D080EsoghTIph9xnbLqcQS3qRBREEC2o21nMEhviAeiGJMelRkKhAkkggjmA==",
       "requires": {
         "@firebase/component": "0.6.8",
         "@firebase/logger": "0.4.2",
@@ -7340,9 +7340,9 @@
       }
     },
     "@firebase/firestore": {
-      "version": "4.6.5",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.6.5.tgz",
-      "integrity": "sha512-0+Ascaht4qUzj4pCopMPWmoAujk8HKjwCpaNYOOjbYMZ65RVfZPsfZwwbWi/zWMXj6xvPsai5oBiErUUkrLwNw==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.7.0.tgz",
+      "integrity": "sha512-wGOp84P1qa1pfpdct6lckfyowTuvIlUDHoiRcN8dFDT4WnZDh0tZW1X77SMiBUVejK8xIRLBCK3yDTejlRVrUA==",
       "requires": {
         "@firebase/component": "0.6.8",
         "@firebase/logger": "0.4.2",
@@ -7376,14 +7376,14 @@
       "integrity": "sha512-jmEnr/pk0yVkA7mIlHNnxCi+wWzOFUg0WyIotgkKAb2u1J7fAeDBcVNSTjTihbAYNusCLQdW5s9IJ5qwnEufcQ=="
     },
     "@gogovega/firebase-config-node": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@gogovega/firebase-config-node/-/firebase-config-node-0.1.0.tgz",
-      "integrity": "sha512-en+5IqmQrEvwX7f80EDX63vWEpalEcO3RNJnPqiindnlrVqpDGBGO4Zp9uH0liXh9BbIr3ui3YoWEjkcGpPbJA==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@gogovega/firebase-config-node/-/firebase-config-node-0.1.1.tgz",
+      "integrity": "sha512-bTLi7Wpy1lguZEMxAOdWwBh1Mbsb5NYyb6vgIXenadJMQoMP0saaBjuyHi1A+ZZvCfPtjvRurB78dr/1CLPNkg==",
       "requires": {
-        "@firebase/app": "0.10.8",
-        "@firebase/auth": "1.7.6",
+        "@firebase/app": "0.10.9",
+        "@firebase/auth": "1.7.7",
         "@firebase/database": "1.0.7",
-        "@firebase/firestore": "4.6.5",
+        "@firebase/firestore": "4.7.0",
         "firebase-admin": "^12.3.1",
         "tiny-typed-emitter": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "version": ">=3"
   },
   "dependencies": {
-    "@gogovega/firebase-config-node": "^0.1.0"
+    "@gogovega/firebase-config-node": "^0.1.1"
   },
   "devDependencies": {
     "@types/node-red": "^1.3.5",

--- a/resources/constraints.js
+++ b/resources/constraints.js
@@ -91,7 +91,18 @@ var FirestoreQueryConstraintsContainer = FirestoreQueryConstraintsContainer || (
 
 		#constraintsHandler() {
 			if (this.useConstraints?.prop("checked") === true) {
-				const constraints = Object.entries(this.node.constraints || {});
+				const constraints = Object.entries(this.node.constraints || {}).reduce((array, [type, value]) => {
+					// For `orderBy` or `where`
+					if (Array.isArray(value)) {
+						value.forEach((val) => {
+							array.push([type, val]);
+						});
+					} else {
+						array.push([type, value]);
+					}
+
+					return array;
+				}, []);
 
 				if (!constraints.length) constraints.push(["limitToLast", { value: "5", valueType: "num" }]);
 
@@ -163,7 +174,8 @@ var FirestoreQueryConstraintsContainer = FirestoreQueryConstraintsContainer || (
 					case "orderBy":
 						if (pathType === "str" && validators.path()(path) !== true) RED.notify("Query Constraints: Setted value is not a valid path!", "error");
 
-						node.constraints[constraintType] = { path: path, pathType: pathType, direction: options };
+						node.constraints[constraintType] ||= [];
+						node.constraints[constraintType].push({ path: path, pathType: pathType, direction: options });
 						break;
 					case "select": {
 						const result = isSelectValueValid(value, {});
@@ -178,7 +190,8 @@ var FirestoreQueryConstraintsContainer = FirestoreQueryConstraintsContainer || (
 					case "where":
 						if (pathType === "str" && validators.path()(path) !== true) RED.notify("Query Constraints: Setted value is not a valid path!", "error");
 
-						node.constraints[constraintType] = { path: path, pathType: pathType, value: value, valueType: valueType, filter: options };
+						node.constraints[constraintType] ||= [];
+						node.constraints[constraintType].push({ path: path, pathType: pathType, value: value, valueType: valueType, filter: options });
 						break;
 				}
 			});

--- a/src/lib/types/firestore-config.ts
+++ b/src/lib/types/firestore-config.ts
@@ -85,12 +85,12 @@ interface Constraint {
 	endBefore?: FieldValues;
 	limitToFirst?: Limit;
 	limitToLast?: Limit;
-	orderBy?: OrderBy;
+	orderBy?: Array<OrderBy>;
 	offset?: Offset;
 	select?: Select;
 	startAfter?: FieldValues;
 	startAt?: FieldValues;
-	where?: Where;
+	where?: Array<Where>;
 }
 
 export type DocumentChangeType = "added" | "removed" | "modified";


### PR DESCRIPTION
The value of the `orderBy` and `where` properties becomes an array to allow use on multiple fields.

Example of `msg.constraints`:
```js
{
  where: [{
    fieldPath: "salary",
    filter: ">",
    value: 100000
  },
  {
    fieldPath: "experience",
    filter: ">",
    value: 0
  }],
  orderBy: [{
    fieldPath: "salary",
    direction: "asc"
  },
  {
    fieldPath: "experience",
    direction: "asc"
  }]
}
```

Is similar to the following writing:

```js
db.collection("employees")
  .where("salary", ">", 100000)
  .where("experience", ">", 0)
  .orderBy("salary")
  .orderBy("experience");
```