### PR TITLE
Skip database initialization if Config Node version is not satisfied

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,6 +26,10 @@ jobs:
       - name: Install Dependencies
         run: npm ci
 
+      # Ensure the required version is up to date
+      - name: Update the Required Config Node version
+        run: node ./scripts/update-required-config-node-version.js
+
       - name: Build
         run: npm run build
 

--- a/scripts/update-required-config-node-version.js
+++ b/scripts/update-required-config-node-version.js
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+
+/**
+ * Copyright 2023-2024 Gauthier Dandele
+ *
+ * Licensed under the MIT License,
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://opensource.org/licenses/MIT.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const { join } = require("node:path");
+const { existsSync, readFileSync, writeFileSync } = require("node:fs");
+
+const filePath = "src/lib/utils.ts";
+
+const versionRegex = /requiredVersion = \[([0-9], [0-9]+, [0-9]+)\]/;
+
+try {
+	console.log("Check if the required Config Node version is up to date...");
+
+	const packageFile = require("../package.json");
+	const destinationFilePath = join(__dirname, "../", filePath);
+
+	if (existsSync(destinationFilePath)) {
+		const destinationFile = readFileSync(destinationFilePath, { encoding: "utf8" });
+
+		const requiredVersionString = packageFile.dependencies["@gogovega/firebase-config-node"];
+
+		const requiredVersionRow = /([0-9]\.[0-9]+\.[0-9]+)/.exec(requiredVersionString);
+		const currentVersionRow = versionRegex.exec(destinationFile);
+
+		if (requiredVersionRow && currentVersionRow) {
+			const requiredVersion = requiredVersionRow[1].replace(/\./g, ", ");
+			const currentVersion = currentVersionRow[1];
+
+			console.log(`Current version:  [${currentVersion}]\nRequired Version: [${requiredVersion}]`);
+
+			if (currentVersion !== requiredVersion) {
+				const contentToWrite = destinationFile.replace(versionRegex, `requiredVersion = [${requiredVersion}]`);
+				console.log("Writing...");
+				writeFileSync(destinationFilePath, contentToWrite, { encoding: "utf8" });
+				console.log("Write done");
+			} else {
+				console.log("The required version is up to date");
+			}
+		}
+	}
+
+	console.log("Done.");
+} catch (error) {
+	console.error("An error occurred while updating:", error);
+}

--- a/src/lib/firestore-node.ts
+++ b/src/lib/firestore-node.ts
@@ -41,6 +41,7 @@ import {
 	NodeConfig,
 	OutgoingMessage,
 } from "./types";
+import { checkConfigNodeSatisfiesVersion } from "./utils";
 
 class Firestore<Node extends FirestoreNode, Config extends FirestoreConfig = NodeConfig<Node>> {
 	private readonly serviceType: ServiceType = "firestore";
@@ -77,6 +78,15 @@ class Firestore<Node extends FirestoreNode, Config extends FirestoreConfig = Nod
 
 		if (!isFirebaseConfigNode(node.database) && node.database)
 			throw new Error("The selected database is not compatible with this module, please check your config-node");
+
+		if (node.database) {
+			if (!checkConfigNodeSatisfiesVersion(RED, node.database.version)) {
+				node.status({ fill: "red", shape: "ring", text: "Invalid Database Version!" });
+
+				// To avoid initializing the database (avoid creating unhandled errors)
+				node.database = null;
+			}
+		}
 	}
 
 	/**

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2023-2024 Gauthier Dandele
+ *
+ * Licensed under the MIT License,
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://opensource.org/licenses/MIT.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { NodeAPI } from "node-red";
+
+/**
+ * The required version of the {@link https://github.com/GogoVega/Firebase-Config-Node | Config Node}.
+ */
+const requiredVersion = [0, 1, 1];
+
+/**
+ * This flag prevents emitting an error log for each Firestore node.
+ *
+ * Indeed the {@link checkConfigNodeSatisfiesVersion} function is called in the Firestore Class which
+ * is the base of each Firestore node.
+ */
+let errorEmitted = false;
+
+/**
+ * Checks if the {@link https://github.com/GogoVega/Firebase-Config-Node | Config Node} version matches
+ * the version required by this Firestore palette.
+ *
+ * When installing this palette, NPM may install the Config Node inside the Firestore palette which results
+ * that Node-RED not loading the correct version.
+ *
+ * @param RED The NodeAPI
+ * @param version The current version of the Config Node
+ * @returns `true` if the version of the Config Node is satisfied
+ */
+function checkConfigNodeSatisfiesVersion(RED: NodeAPI, version: string): boolean {
+	if (errorEmitted) return false;
+
+	const match = /([0-9])\.([0-9]+)\.([0-9]+)/.exec(version);
+	if (match) {
+		match.shift();
+
+		const [major, minor, patch] = match.map((v) => parseInt(v, 10));
+
+		if (
+			major > requiredVersion[0] ||
+			(major === requiredVersion[0] &&
+				(minor > requiredVersion[1] || (minor === requiredVersion[1] && patch >= requiredVersion[2])))
+		)
+			return true;
+
+		errorEmitted = true;
+
+		RED.log.error("FIREBASE: The Config Node version does not meet the requirements of this palette.");
+		RED.log.error("  Required Version: " + requiredVersion.join("."));
+		RED.log.error("  Current Version:  " + version);
+		RED.log.error(
+			"  Please run the following command to resolve the issue:\n\n    cd ~/.node-red\n    npm update --omit=dev\n"
+		);
+
+		return false;
+	}
+
+	// Not supposed to happen
+	return true;
+}
+
+export { checkConfigNodeSatisfiesVersion };


### PR DESCRIPTION
The Config Node allows to use the Cloud Firestore palette and the RTDB palette at the same time.

But the installation can cause a problem: if the RTDB palette is already installed NPM will install the Config Node package in the Cloud Firestore package instead of updating the existing.

This PR prevents the database initialization and asks the user to update packages.

In addition this PR contains a script that ensures that the required version of the Config Node is always up to date.