### PR TITLE
Improve Config Node version checking

### DIFF
--- a/resources/common.js
+++ b/resources/common.js
@@ -249,34 +249,8 @@ var FirestoreUI = FirestoreUI || (function () {
 		return RED._(`@gogovega/node-red-contrib-cloud-firestore/${dict}:${group || dict}.${key}`, tplStrs);
 	}
 
-	// --- Firebase Config Node Part ---
-	function generateNotification() {
-		const msg = `
-			<html>
-				<p>Welcome to Google Cloud Firestore</p>
-				<p>To use this palette of nodes, please restart Node-RED. If you are using FlowFuse, suspend then start the instance.</p>
-				<p>If you have installed from the Manage Palette you need to restart because Node-RED did not load all nodes correctly.</p>
-				<p>Read more about this issue <a href="https://github.com/GogoVega/node-red-contrib-firebase-realtime-database/discussions/50">here</a>.</p>
-			</html>`;
-
-		const myNotification = RED.notify(msg, {
-			type: "warning",
-			fixed: true,
-			modal: true,
-			buttons: [{
-				text: "Close",
-				class: "primary",
-				click: () => {
-					myNotification.close();
-				}
-			}],
-		});
-	}
-
-	// Config Node not loaded, so the user must restart NR
-	if (!RED.nodes.getType("firebase-config")) {
-		generateNotification();
-	}
+	// Check the Firebase Config Node
+	$.getScript("resources/@gogovega/node-red-contrib-cloud-firestore/config-node.js");
 
 	return {
 		_: i18nFullOptions,

--- a/resources/config-node.js
+++ b/resources/config-node.js
@@ -1,0 +1,198 @@
+/**
+ * Copyright 2023-2024 Gauthier Dandele
+ *
+ * Licensed under the MIT License,
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://opensource.org/licenses/MIT.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+; (function () {
+	"use strict";
+
+	const notify = function (notifications) {
+		if (!Array.isArray(notifications)) {
+			notifications = [notifications];
+		}
+
+		notifications.forEach((notification) => {
+			const { buttons, fixed, modal, msg, type } = notification;
+			const myNotification = RED.notify(msg, {
+				modal: modal,
+				fixed: fixed,
+				type: type,
+				buttons: (function () {
+					return buttons.map((button) => {
+						if (button === "Close" || button === "Cancel") {
+							return {
+								text: button,
+								class: "primary",
+								click: () => {
+									myNotification.close();
+								}
+							};
+						} else if (button === "View Log") {
+							return {
+								text: button,
+								class: "pull-left",
+								click: () => {
+									RED.actions.invoke("core:show-event-log");
+								}
+							};
+						} else if (button === "Confirm Update") {
+							const path = "firebase/firestore/config-node/scripts";
+
+							return {
+								text: "Confirm",
+								click: (event) => {
+									const spinner = RED.utils.addSpinnerOverlay($(event.target));
+
+									// Start the event log panel
+									RED.eventLog.startEvent("FIRESTORE: Updating dependencies...");
+
+									$.post(path, { script: "update-dependencies" }, function (resp) {
+										spinner.remove();
+										myNotification.close();
+										
+										if (resp.status === "success") {
+											notify({
+												msg: "<html><p>Update Successful!</p><p>Restarts now Node-RED and reload your browser</p></html>",
+												type: "success",
+												fixed: true,
+												buttons: ["Close"]
+											});
+										} else if (resp.status === "error") {
+											notify({
+												msg: `
+												<html>
+													<p>Update Failed!</p>
+													<p>Please raise an issue <a href="https://github.com/GogoVega/node-red-contrib-cloud-firestore/issues/new/choose">here</a> with log details:</p>
+													<pre>${resp.msg}</pre>
+												</html>`,
+												type: "error",
+												fixed: true,
+												buttons: ["Close"],
+											});
+										} else {
+											console.log("J'ai glissé chef!");
+										}
+									});
+								}
+							};
+						} else if (button === "Run Update") {
+							return {
+								text: button,
+								class: "pull-left",
+								click: () => {
+									myNotification.close();
+									notify([{
+										msg: `
+											<html>
+												<p>Are you really sure you want to do this?</p>
+												<p>The Update script will run <code>npm update</code> in your Node-RED directory to update dependencies.</p>
+												<p><strong>Tip</strong>: Click on <strong>View Log</strong> then <strong>Confirm</strong> and not the other way around 🤫</p>
+											</html>`,
+										modal: false, fixed: true, type: "warning", buttons: ["Confirm Update", "View Log", "Cancel"]
+									}]);
+								}
+							};
+						} else {
+							console.error("Unknown button", button);
+							return {};
+						}
+					});
+				})(),
+			});
+		});
+	};
+
+	function generateNotification(script) {
+		const updateMsg = `
+			<html>
+				<p>Welcome to Google Cloud Firestore</p>
+				<p>The Config Node version don't meet the version required by the Cloud Firestore palette.</p>
+				<p>
+					Can happen when you use both Cloud Firestore and <a href="https://flows.nodered.org/node/@gogovega/node-red-contrib-firebase-realtime-database">RTDB</a> palettes.
+					Indeed NPM installs a new version into the wrong package instead of updating the existing one.
+				</p>
+				<p>To solve this issue, please run the Update script.</p>
+			</html>`;
+		const restartMsg = `
+			<html>
+				<p>Welcome to Google Cloud Firestore</p>
+				<p>To use this palette of nodes, please restart Node-RED. If you are using FlowFuse, suspend then start the instance.</p>
+				<p>If you have installed from the Manage Palette you need to restart because Node-RED did not load all nodes correctly.</p>
+				<p>Read more about this issue <a href="https://github.com/GogoVega/node-red-contrib-firebase-realtime-database/discussions/50">here</a>.</p>
+			</html>`;
+		const restartAfterUpdateMsg = `
+			<html>
+				<p>Don't forget to restart Node-RED!</p>
+				<p>It looks like you didn't restart Node-RED after running the Update script 🙄</p>
+			</html>`;
+
+		let msg;
+		let buttons = ["Close"];
+		switch (script) {
+			case "update":
+				msg = updateMsg;
+				buttons = ["Run Update", "Close"];
+				break;
+			case "restart":
+				msg = restartMsg;
+				break;
+			case "restart-update":
+				msg = restartAfterUpdateMsg;
+				break;
+			default:
+				throw new Error("Unknown notification script: " + script);
+		}
+
+		notify([{
+			msg: msg,
+			type: "warning",
+			fixed: true,
+			modal: true,
+			buttons: buttons,
+		}]);
+	}
+
+	function installFromPaletteManager() {
+		return !RED.nodes.getType("firebase-config");
+	}
+
+	function init() {
+		try {
+			console.log("Firestore Check Worker Started");
+
+			// Config Node not loaded, so the user must restart NR
+			if (installFromPaletteManager()) {
+				generateNotification("restart");
+				return;
+			}
+
+			// Research if the Config Node version satisfies the required version by this palette
+			$.getJSON("firebase/firestore/config-node/status", function (result) {
+				if (!result.status.versionIsSatisfied) {
+					if (result.status.updateScriptCalled) {
+						// The user has triggered the Update script but not restarted NR
+						generateNotification("restart-update");
+					} else {
+						// Ask the user to trigger the Update script
+						generateNotification("update");
+					}
+				}
+			});
+		} catch (error) {
+			console.error("An error occurred while checking the status of the config-node", error);
+		}
+	}
+
+	setTimeout(init, 200);
+})();

--- a/src/lib/endpoints.ts
+++ b/src/lib/endpoints.ts
@@ -1,0 +1,86 @@
+/**
+ * Copyright 2023-2024 Gauthier Dandele
+ *
+ * Licensed under the MIT License,
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://opensource.org/licenses/MIT.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { NodeAPI } from "node-red";
+import { Request, Response } from "express";
+import { runUpdateDependencies, versionIsSatisfied } from "./utils";
+
+/**
+ * To avoid running the script multiple times
+ *
+ * @internal
+ */
+let updateScriptCalled: boolean = false;
+
+function configNodeStatusHandler(_req: Request, res: Response) {
+	res.json({
+		status: {
+			versionIsSatisfied: versionIsSatisfied(),
+			updateScriptCalled: updateScriptCalled,
+		},
+	});
+}
+
+async function updateDependenciesHandler(RED: NodeAPI, req: Request, res: Response) {
+	try {
+		const scriptName = req.body.script;
+
+		if (scriptName === "update-dependencies") {
+			if (updateScriptCalled) throw new Error("Update Script already called");
+
+			updateScriptCalled = true;
+
+			if (!RED.settings.userDir) throw new Error("Node-RED 'userDir' Setting not available");
+
+			// @node-red/util.exec is not imported to NodeAPI, so it's a workaround to get it
+			// TODO: if there is a risk that the "require" fails, make a locally revisited copy
+			let utilPath = join(process.env.NODE_RED_HOME || ".", "node_modules", "@node-red/util");
+
+			if (!existsSync(utilPath)) {
+				// Some installations like FlowFuse use this path
+				utilPath = join(process.env.NODE_RED_HOME || ".", "../", "@node-red/util");
+			}
+
+			// eslint-disable-next-line @typescript-eslint/no-require-imports
+			const exec = require(utilPath).exec;
+
+			RED.log.info("Starting to update Node-RED dependencies...");
+
+			await runUpdateDependencies(RED, exec);
+
+			RED.log.info("Successfully updated Node-RED dependencies. Please restarts Node-RED.");
+		} else {
+			// Forbidden
+			res.sendStatus(403);
+			return;
+		}
+
+		res.json({ status: "success" });
+	} catch (error) {
+		const msg = error instanceof Error ? error.toString() : (error as Record<"stderr", string>).stderr;
+
+		RED.log.error("An error occured while updating Node-RED dependencies: " + msg);
+
+		res.json({
+			status: "error",
+			msg: msg,
+		});
+	}
+}
+
+export { configNodeStatusHandler, updateDependenciesHandler };

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -18,16 +18,22 @@ import { NodeAPI } from "node-red";
 
 /**
  * The required version of the {@link https://github.com/GogoVega/Firebase-Config-Node | Config Node}.
+ *
+ * WARNING: Do not change the name because it's used by the publish script!
+ *
+ * @internal
  */
 const requiredVersion = [0, 1, 2];
 
 /**
- * This flag prevents emitting an error log for each Firestore node.
+ * Cache system to not read files multiple times.
  *
- * Indeed the {@link checkConfigNodeSatisfiesVersion} function is called in the Firestore Class which
- * is the base of each Firestore node.
+ * Indeed the {@link checkConfigNodeSatisfiesVersion} function is called in the Firebase Class which
+ * is the base of each Firebase node.
+ *
+ * @internal
  */
-let errorEmitted = false;
+const cacheResult = { cached: false, errorEmitted: false };
 
 /**
  * Checks if the {@link https://github.com/GogoVega/Firebase-Config-Node | Config Node} version matches
@@ -41,7 +47,10 @@ let errorEmitted = false;
  * @returns `true` if the version of the Config Node is satisfied
  */
 function checkConfigNodeSatisfiesVersion(RED: NodeAPI, version: string): boolean {
-	if (errorEmitted) return false;
+	if (cacheResult.errorEmitted) return false;
+	if (cacheResult.cached) return true;
+
+	cacheResult.cached = true;
 
 	const match = /([0-9])\.([0-9]+)\.([0-9]+)/.exec(version);
 	if (match) {
@@ -56,9 +65,9 @@ function checkConfigNodeSatisfiesVersion(RED: NodeAPI, version: string): boolean
 		)
 			return true;
 
-		errorEmitted = true;
+		cacheResult.errorEmitted = true;
 
-		RED.log.error("FIREBASE: The Config Node version does not meet the requirements of this palette.");
+		RED.log.error("FIRESTORE: The Config Node version does not meet the requirements of this palette.");
 		RED.log.error("  Required Version: " + requiredVersion.join("."));
 		RED.log.error("  Current Version:  " + version);
 		RED.log.error(
@@ -72,4 +81,40 @@ function checkConfigNodeSatisfiesVersion(RED: NodeAPI, version: string): boolean
 	return true;
 }
 
-export { checkConfigNodeSatisfiesVersion };
+type Exec = Record<"run", (command: string, args: string[], option: object, emit: boolean) => Promise<object>>;
+
+/**
+ * Run a system command with stdout/err being emitted as notification to the Event Log panel.
+ *
+ * @param RED The NodeAPI
+ * @param exec The `@node-red/util.exec` instance (because not imported to NodeAPI)
+ * @returns A promise that resolves (rc=0) or rejects (rc!=0) when the command completes.
+ */
+function runUpdateDependencies(RED: NodeAPI, exec: Exec): Promise<object> {
+	const isWindows = process.platform === "win32";
+	const npmCommand = isWindows ? "npm.cmd" : "npm";
+	const extraArgs = [
+		"--no-audit",
+		"--no-update-notifier",
+		"--no-fund",
+		"--save",
+		"--save-prefix=~",
+		"--omit=dev",
+		"--engine-strict",
+	];
+	const args = ["update", ...extraArgs];
+	const userDir = RED.settings.userDir || process.env.NODE_RED_HOME || ".";
+
+	return exec.run(npmCommand, args, { cwd: userDir, shell: true }, true);
+}
+
+/**
+ * Check if the Config Node version satisfies the required version by this palette.
+ *
+ * @returns `true` if the version is satisfied
+ */
+function versionIsSatisfied(): boolean {
+	return !cacheResult.errorEmitted;
+}
+
+export { checkConfigNodeSatisfiesVersion, runUpdateDependencies, versionIsSatisfied };

--- a/src/nodes/firestore-out.ts
+++ b/src/nodes/firestore-out.ts
@@ -17,8 +17,27 @@
 import { NodeAPI } from "node-red";
 import { FirestoreOut } from "../lib/firestore-node";
 import { FirestoreOutConfig, FirestoreOutNode } from "../lib/types";
+import { configNodeStatusHandler, updateDependenciesHandler } from "../lib/endpoints";
 
 module.exports = function (RED: NodeAPI) {
+	// ----- ENDPOINTS FOR ALL FIRESTORE NODES ----- //
+
+	// Check if the Config Node version satisfies the require one
+	RED.httpAdmin.get(
+		"/firebase/firestore/config-node/status",
+		RED.auth.needsPermission("firestore-out.write"),
+		configNodeStatusHandler
+	);
+
+	// Run the Update Script
+	RED.httpAdmin.post(
+		"/firebase/firestore/config-node/scripts",
+		RED.auth.needsPermission("firestore-out.write"),
+		(req, resp) => updateDependenciesHandler(RED, req, resp)
+	);
+
+	// TODO: Autocomplete endpoint
+
 	function FirestoreOutNode(this: FirestoreOutNode, config: FirestoreOutConfig) {
 		RED.nodes.createNode(this, config);
 


### PR DESCRIPTION
The following has been added if the Config Node version does not meet the version required by this palette:
- A notification system to warn the user of the Config Node status
- A script that automatically updates dependencies (runnable from the notification)

See https://github.com/GogoVega/node-red-contrib-firebase-realtime-database/pull/71 for more infos.