### PR TITLE
Allow `Firestore IN` to be dynamic

### DIFF
--- a/build/nodes/firestore-in.html
+++ b/build/nodes/firestore-in.html
@@ -26,6 +26,12 @@
 		const { generateToolTip, typedPathField, validators } = FirestoreUI;
 		const i18n = (key) => FirestoreUI._(key, "firestore-in");
 
+		const isDynamic = function (type = "str", value) {
+			return type === "msg" ? true : (type !== "str" && type !== "env")
+				? /\[msg/.test(value ?? "")
+				: false;
+		};
+
 		RED.nodes.registerType("firestore-in", {
 			align: "left",
 			category: "Firestore",
@@ -55,9 +61,9 @@
 				return this.name ? "node_label_italic" : "";
 			},
 			oneditprepare: function () {
-				const collectionField = typedPathField.create("collection").modeByDefault("static");
-				const collectionGroupField = typedPathField.create("collectionGroup").modeByDefault("static").allowSlash(false);
-				const documentField = typedPathField.create("document").modeByDefault("static");
+				const collectionField = typedPathField.create("collection");
+				const collectionGroupField = typedPathField.create("collectionGroup").allowSlash(false);
+				const documentField = typedPathField.create("document");
 
 				collectionField.build();
 				collectionGroupField.build();
@@ -136,7 +142,19 @@
 					collectionGroupType.val("str");
 				}
 
-				const inputs = refType === "none" ? 1 : 0;
+				const filterDynamic = $("#node-input-filter").val() === "msg";
+				const pathDynamic = [collection, collectionGroup, document].some((field) =>
+					isDynamic(field.typedInput("type"), field.typedInput("value")));
+				const constraintDynamic = Object.values(this.constraints).some((values) => {
+					if (!Array.isArray(values)) values = [values];
+					return values.some((constraint) => {
+						if (Object.keys(constraint).length > 3) {
+							if (isDynamic(constraint.valueType, constraint.value)) return true;
+						}
+						return isDynamic(constraint.pathType ?? constraint.valueType, constraint.path ?? constraint.value);
+					});
+				});
+				const inputs = (filterDynamic || pathDynamic || constraintDynamic) ? 1 : 0;
 				$("#node-input-inputs").val(inputs);
 			},
 			oneditresize: (size) => editableConstraintsList.reSize(size),
@@ -159,7 +177,7 @@
 		<input type="hidden" id="node-input-inputs" />
 		<label for="node-input-referenceType"><i class="fa fa-bars"></i> <span data-i18n="firestore-in.label.referenceType"></span></label>
 		<select id="node-input-referenceType" style="width:70%;">
-			<option value="none" data-i18n="firestore-in.reference.none" disabled></option>
+			<option value="none" data-i18n="firestore-in.reference.none"></option>
 			<option value="collection" data-i18n="firestore-in.reference.collection"></option>
 			<option value="collectionGroup" data-i18n="firestore-in.reference.collectionGroup"></option>
 			<option value="document" data-i18n="firestore-in.reference.document"></option>
@@ -197,7 +215,7 @@
 	<div class="form-row form-row-ref form-row-collection form-row-collectionGroup">
 		<label for="node-input-filter"><i class="fa fa-sign-out"></i> <span data-i18n="firestore-in.label.filter"></span></label>
 		<select id="node-input-filter" style="width:70%;">
-			<option value="msg" data-i18n="firestore-in.filter.msg" disabled></option>
+			<option value="msg" data-i18n="firestore-in.filter.msg"></option>
 			<option value="none" data-i18n="firestore-in.filter.none"></option>
 			<option value="added" data-i18n="firestore-in.filter.added"></option>
 			<option value="modified" data-i18n="firestore-in.filter.modified"></option>

--- a/build/nodes/locales/en-US/firestore-in.html
+++ b/build/nodes/locales/en-US/firestore-in.html
@@ -29,6 +29,8 @@
 	<dl class="message-properties">
 		<dt class="optional">constraints<span class="property-type">object</span></dt>
 		<dd>an object containing the constraint(s) to apply to the query.</dd>
+		<dt class="optional">filter<span class="property-type">string</span></dt>
+		<dd>the filter to apply to the query.</dd>
 	</dl>
 	<h3>Outputs</h3>
 	<dl class="message-properties">
@@ -60,7 +62,13 @@
 	</p>
 	<p>
 		The <strong>Filter</strong> filters <code>payload.changes</code> to keep only the documents
-		whose change type matches the applied filter.
+		whose change type matches the applied filter. You can set it dynamically with <code>msg.filter</code>
+		and one of the following values: <code>added</code>, <code>modified</code>, <code>removed</code>
+		or <code>reset</code>.
+	</p>
+	<p>
+		For each valid message received, the subscription will be replaced by the new one.
+		You can also stop a subscription by using the <code>reset</code> value.
 	</p>
 	<ul>
 		<li><code>endAt</code><span class="property-type">various</span></li>

--- a/build/nodes/locales/fr/firestore-in.html
+++ b/build/nodes/locales/fr/firestore-in.html
@@ -29,6 +29,8 @@
 	<dl class="message-properties">
 		<dt class="optional">constraints<span class="property-type">objet</span></dt>
 		<dd>un objet contenant la ou les contraintes à appliquer à la requête.</dd>
+		<dt class="optional">filter<span class="property-type">chaîne de caractères</span></dt>
+		<dd>le filtre à appliquer à la requête.</dd>
 	</dl>
 	<h3>Sorties</h3>
 	<dl class="message-properties">
@@ -53,7 +55,13 @@
 	</p>
 	<p>
 		Le <strong>Filtre</strong> filtre <code>payload.changes</code> afin de ne garder que les documents
-		dont le type de changement correspond au filtre appliqué.
+		dont le type de changement correspond au filtre appliqué. Vous pouvez le définir dynamiquement avec
+		<code>msg.filter</code> et une des valeurs suivantes : <code>added</code>, <code>modified</code>,
+		<code>removed</code> ou <code>reset</code>.
+	</p>
+	<p>
+		Pour chaque message valide reçu, la souscription sera remplacée par la nouvelle.
+ 		Vous pouvez également arrêter une souscription en utilisant la valeur <code>reset</code>.
 	</p>
 	<p>
 		Vous pouvez définir des contraintes pour la requête afin de trier et d'ordonner vos données. Vous pouvez définir une

--- a/src/lib/firestore-node.ts
+++ b/src/lib/firestore-node.ts
@@ -29,6 +29,7 @@ import { ConfigNode, ServiceType } from "@gogovega/firebase-config-node/types";
 import { Entry, isFirebaseConfigNode } from "@gogovega/firebase-config-node/utils";
 import {
 	DocumentChangeType,
+	Filter,
 	FirestoreConfig,
 	FirestoreGetConfig,
 	FirestoreGetNode,
@@ -416,19 +417,8 @@ class Firestore<Node extends FirestoreNode, Config extends FirestoreConfig = Nod
 
 		if (!this.isFirestoreInNode(this.node)) this.setStatus("Query Done", 500);
 
-		if (
-			snapshot &&
-			"changes" in snapshot &&
-			this.isFirestoreInNode(this.node) &&
-			this.node.config.filter &&
-			this.node.config.filter !== "none"
-		) {
-			const filterAllowed: Array<DocumentChangeType> = ["added", "modified", "removed"];
-			const filter = this.node.config.filter === "msg" ? msg?.filter : this.node.config.filter;
-
-			if (filter && !filterAllowed.includes(filter)) throw new Error("Unknown filter (DocumentChangeType).");
-
-			snapshot.changes = (snapshot as CollectionData).changes.filter((doc) => doc.type === filter);
+		if (snapshot && this instanceof FirestoreIn && "changes" in snapshot && this.filter !== "none") {
+			snapshot.changes = (snapshot as CollectionData).changes.filter((doc) => doc.type === this.filter);
 		}
 
 		const msg2Send: OutgoingMessage = {
@@ -466,6 +456,13 @@ class Firestore<Node extends FirestoreNode, Config extends FirestoreConfig = Nod
 				break;
 			case "Query Done":
 				this.node.status({ fill: "blue", shape: "dot", text: "Query Done!" });
+				break;
+			case "Subscribed":
+			case "Unsubscribed":
+				this.node.status({ fill: "blue", shape: "dot", text: status });
+				break;
+			case "Waiting":
+				this.node.status({ fill: "blue", shape: "ring", text: "Waiting for Subscription..." });
 				break;
 			case "":
 				this.node.database?.setCurrentStatus(this.node.id);
@@ -508,6 +505,15 @@ export class FirestoreGet extends Firestore<FirestoreGetNode> {
 }
 
 export class FirestoreIn extends Firestore<FirestoreInNode> {
+	private static filterAllowed: Array<Filter> = ["added", "modified", "removed", "none"];
+
+	private _filter?: Filter;
+
+	/**
+	 * Whether the node should await a payload to subscribe to data.
+	 */
+	private isDynamicConfig: boolean = false;
+
 	/**
 	 * This property contains the **function to call** to unsubscribe the listener
 	 */
@@ -515,28 +521,81 @@ export class FirestoreIn extends Firestore<FirestoreInNode> {
 
 	constructor(node: FirestoreInNode, config: FirestoreInConfig, RED: NodeAPI) {
 		super(node, config, RED);
+
+		// No need to re-check all config - if the node has an input, the config is dynamic.
+		this.isDynamicConfig = this.node.config.inputs === 1;
 	}
 
-	//public subscribe(): void;
-	//public subscribe(msg: IncomingMessage, send: (msg: NodeMessage) => void, done: (error?: Error) => void): void;
-	public subscribe(): void {
+	public get filter(): Filter | undefined {
+		return this._filter;
+	}
+
+	private getFilter(msg?: IncomingMessage): Filter {
+		const { filter } = this.node.config;
+
+		// Dynamic Filter ? Skip the static subscription
+		if (filter === "msg" && !msg) return filter;
+
+		const docChangeType = filter === "msg" ? (msg?.filter as DocumentChangeType | undefined) : filter;
+
+		if (typeof docChangeType !== "string" || !FirestoreIn.filterAllowed.includes(docChangeType))
+			throw new Error(`Unknown filter (DocumentChangeType): Received ${docChangeType}.`);
+
+		return docChangeType;
+	}
+
+	public subscribe(): void;
+	public subscribe(msg: IncomingMessage, send: (msg: NodeMessage) => void, done: (error?: Error) => void): void;
+	public subscribe(msg?: IncomingMessage, send?: (msg: NodeMessage) => void, done?: (error?: Error) => void): void {
 		(async () => {
 			try {
-				if (!this.firestore) return;
+				if (!this.firestore) {
+					if (done) done();
+					return;
+				}
 
-				const config = await this.getQueryConfig();
+				const msg2PassThrough = this.node.config.passThrough ? msg : undefined;
 
-				// TODO: Dynamic mode
+				// Unsubscribe and passthrough the msg
+				if (msg && msg.filter === "reset") {
+					this.unsubscribe();
+					this.setStatus("Unsubscribed");
+					if (send && msg2PassThrough) send(msg2PassThrough);
+					if (done) done();
+					return;
+				}
 
-				if (!(await this.node.database?.clientSignedIn())) return;
+				// Not work when starting the flow
+				// TODO: need LocalStatus to resolve it
+				this.setStatus("Waiting");
 
+				// Await the filter defined in the incoming message
+				this._filter = this.getFilter(msg);
+				if (this._filter === "msg" || (this.isDynamicConfig && !msg)) {
+					if (done) done();
+					return;
+				}
+
+				const config = await this.getQueryConfig(msg);
+
+				if (!(await this.node.database?.clientSignedIn())) {
+					if (done) done();
+					return;
+				}
+
+				this.unsubscribe();
 				this.unsubscribeCallback = this.firestore?.subscribe(
 					config,
 					(snapshot) => this.sendMsg(snapshot),
 					(error) => this.onError(error)
 				);
+
+				this.setStatus("Subscribed", 2000);
+
+				if (send && msg2PassThrough) send(msg2PassThrough);
+				if (done) done();
 			} catch (error) {
-				this.onError(error);
+				this.onError(error, done);
 			}
 		})();
 	}

--- a/src/lib/types/firestore-config.ts
+++ b/src/lib/types/firestore-config.ts
@@ -94,6 +94,7 @@ interface Constraint {
 }
 
 export type DocumentChangeType = "added" | "removed" | "modified";
+export type Filter = DocumentChangeType | "msg" | "none";
 
 interface QueryOption {
 	merge: boolean;
@@ -120,7 +121,8 @@ export interface FirestoreInConfig extends NodeDef {
 	constraints: Constraint;
 	document: Document;
 	documentType: DocumentType;
-	filter: DocumentChangeType | "msg" | "none";
+	filter: Filter;
+	inputs: 0 | 1;
 	passThrough: boolean;
 }
 

--- a/src/lib/types/firestore-node.ts
+++ b/src/lib/types/firestore-node.ts
@@ -25,7 +25,7 @@ interface QueryOptions {
 
 export interface IncomingMessage extends NodeMessageInFlow {
 	constraints?: Constraint;
-	filter?: DocumentChangeType;
+	filter?: DocumentChangeType | "reset";
 	method?: QueryMethod;
 	options?: QueryOptions;
 }

--- a/src/nodes/firestore-in.ts
+++ b/src/nodes/firestore-in.ts
@@ -27,8 +27,7 @@ module.exports = function (RED: NodeAPI) {
 		firestore.attachStatusListener();
 		firestore.subscribe();
 
-		// TODO: Dynamic mode
-		//this.on("input", (msg, send, done) => firestore.subscribe(msg, send, done));
+		this.on("input", (msg, send, done) => firestore.subscribe(msg, send, done));
 
 		this.on("close", (done: () => void) => {
 			firestore.unsubscribe();


### PR DESCRIPTION
Depending on the configuration, the node can have an input to allow dynamic properties.

If `msg.filter` is set to `reset` it detaches the listener (unsubscribes).
Each valid message will replace the current listener.

New statuses have been added to improve tracking.