### PR TITLE
Ignore `evaluatePayloadForFieldValue` if payload is undefined

### DIFF
--- a/src/lib/firestore-node.ts
+++ b/src/lib/firestore-node.ts
@@ -175,6 +175,7 @@ class Firestore<Node extends FirestoreNode, Config extends FirestoreConfig = Nod
 	 * @returns The payload evaluated
 	 */
 	protected evaluatePayloadForFieldValue(payload: unknown): object {
+		if (typeof payload === "undefined") return {};
 		if (typeof payload !== "object" || !payload) throw new TypeError("msg.payload must be an object");
 
 		const fieldValue = new SpecialFieldValue(this.firestore!.client.admin!);


### PR DESCRIPTION
No need to define a payload for the `delete` request - ignore `evaluatePayloadForFieldValue` to avoid throwing an error.