### PR TITLE
Support for `addDoc` to create a doc with auto-generated ID

### DIFF
--- a/build/nodes/firestore-out.html
+++ b/build/nodes/firestore-out.html
@@ -37,7 +37,7 @@
 				collectionType: { value: "str", label: i18n("label.collection"), validate: validators.pathType() },
 				document: { value: "", label: i18n("label.document"), validate: validators.typedInput("documentType") },
 				documentType: { value: "str", label: i18n("label.document"), validate: validators.pathType() },
-				queryMethod: { value: "", label: i18n("label.queryMethod"), validate: validators.queryMethod() },
+				queryMethod: { value: "set", label: i18n("label.queryMethod"), validate: validators.queryMethod() },
 				queryOptions: { value: { merge: false } },
 			},
 			inputs: 1,
@@ -56,6 +56,10 @@
 				documentField.build();
 
 				$("#node-input-merge").prop("checked", this.queryOptions?.merge || false);
+
+				// Allow empty document path for the set method
+				const queryMethod = $("#node-input-queryMethod");
+				queryMethod.on("change", () => documentField.dynamicallyAllowBlank(queryMethod.val() === "set"));
 			},
 			oneditsave: function () {
 				const merge = $("#node-input-merge").prop("checked");

--- a/build/nodes/locales/en-US/firestore-out.html
+++ b/build/nodes/locales/en-US/firestore-out.html
@@ -36,6 +36,7 @@
 		The <strong>Collection</strong> and <strong>Document</strong> determine where the data will be written.
 		They can be set in the node or dynamically.
 	</p>
+	<p>If you want your document to get an auto-generated ID leave the <strong>Document</strong> blank.</p>
 	<p>
 		The reserved keyword <code>"DELETE"</code> allows you to delete a property and its value from the database.
 		It must be written in string format and can be used in an object.

--- a/build/nodes/locales/fr/firestore-out.html
+++ b/build/nodes/locales/fr/firestore-out.html
@@ -36,6 +36,7 @@
 		La <strong>Collection</strong> et le <strong>Document</strong> déterminent où les données seront écrites.
 		Ils peuvent être défini dans le noeud ou dynamiquement.
 	</p>
+	<p>Si vous souhaitez que votre document obtienne un identifiant auto-généré laisser le champ <strong>Document</strong> vide.</p>
 	<p>
 		Le mot-clé réservé <code>"DELETE"</code> permet de supprimer une propriété et sa valeur de la base de données.
 		Il doit être écrit au format chaîne de caractères et peut être utilisé dans un objet.

--- a/resources/common.js
+++ b/resources/common.js
@@ -98,12 +98,18 @@ var FirestoreUI = FirestoreUI || (function () {
 
 					let allowBlank = false, allowSlash = true;
 					if (refSelect.length) {
+						// Validation by the edit box
 						const referenceType = refSelect.val();
 						allowBlank = referenceType !== fieldName;
 						allowSlash = fieldName !== "collectionGroup";
 					} else if (this.type === "firestore-out") {
-						allowBlank = fieldName === "collection";
+						if (fieldName === "collection") {
+							allowBlank = true;
+						} else if (($("#node-input-queryMethod").val() ?? this.queryMethod) === "set") {
+							allowBlank = true;
+						}
 					} else {
+						// Validation by the node
 						if ((this.document || this.collection) && this.collectionGroup) {
 							allowBlank = true;
 							allowSlash = fieldName !== "collectionGroup";


### PR DESCRIPTION
Follows https://github.com/GogoVega/Firebase-Config-Node/pull/23.

With the `Set` method, the document will have an auto-generated ID if the document path is empty.