### PR TITLE
0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Change log
 
+## 0.1.3
+
+### Changes
+
+- Bump `@gogovega/firebase-config-node` from 0.2.3 to 0.2.4
+  - Fix `got` dependency missing - replaced by `axios` ([#22](https://github.com/GogoVega/Firebase-Config-Node/pull/22))
+  - Support for `addDoc` to create a doc with auto-generated id ([#23](https://github.com/GogoVega/Firebase-Config-Node/pull/23))
+
+### Enhances
+
+- Support for addDoc to create a doc with auto-generated ID (#15)
+
+### Fixes
+
+- Add missing validation error messages
+
 ## 0.1.2
 
 ### Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gogovega/node-red-contrib-cloud-firestore",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gogovega/node-red-contrib-cloud-firestore",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "@gogovega/firebase-config-node": "^0.2.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gogovega/node-red-contrib-cloud-firestore",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Node-RED nodes to communicate with Google Cloud Firestore",
   "main": "build/nodes/firestore-in.js",
   "scripts": {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -23,7 +23,7 @@ import { NodeAPI } from "node-red";
  *
  * @internal
  */
-const requiredVersion = [0, 2, 3];
+const requiredVersion = [0, 2, 4];
 
 /**
  * Cache system to not read files multiple times.


### PR DESCRIPTION
## Changes

- Bump `@gogovega/firebase-config-node` from 0.2.3 to 0.2.4
  - Fix `got` dependency missing - replaced by `axios`
  - Support for `addDoc` to create a doc with auto-generated ID

## Enhances

- Support for addDoc to create a doc with auto-generated ID

## Fixes

- Add missing validation error messages