### PR TITLE
Experimental: Force load config node to avoid restarting NR

### DIFF
--- a/build/plugins/config-node-checker.html
+++ b/build/plugins/config-node-checker.html
@@ -48,8 +48,6 @@
 									}
 								};
 							} else if (button === "Confirm Update") {
-								const path = "firebase/firestore/config-node/scripts";
-
 								return {
 									text: "Confirm",
 									click: (event) => {
@@ -60,7 +58,7 @@
 
 										$.ajax({
 											method: "PUT",
-											url: path,
+											url: "firebase/firestore/config-node/scripts",
 											data: { script: "update-dependencies" },
 											success: function (resp) {
 												spinner.remove();
@@ -111,8 +109,6 @@
 									}
 								};
 							} else if (button === "Load Config Node") {
-								const path = "firebase/firestore/config-node/scripts";
-
 								return {
 									text: button,
 									class: "pull-left",
@@ -123,7 +119,7 @@
 
 										$.ajax({
 											method: "PUT",
-											url: path,
+											url: "firebase/firestore/config-node/scripts",
 											data: { script: "load-config-node" },
 											success: function (resp) {
 												spinner.remove();
@@ -191,7 +187,7 @@
 					break;
 				case "restart":
 					msg = restartMsg;
-					buttons = ["Load Config Node", "Close"]
+					buttons = ["Load Config Node", "Close"];
 					break;
 				case "restart-update":
 					msg = restartAfterUpdateMsg;
@@ -250,7 +246,7 @@
 							} else {
 								// All ready => run the 'First flow' guide
 								const plugin = RED.plugins.getPlugin("firestore-tours-runner");
-								
+
 								if (plugin && typeof plugin.runner === "function") {
 									plugin.runner();
 								}

--- a/build/plugins/config-node-checker.html
+++ b/build/plugins/config-node-checker.html
@@ -110,6 +110,28 @@
 										}]);
 									}
 								};
+							} else if (button === "Load Config Node") {
+								const path = "firebase/firestore/config-node/scripts";
+
+								return {
+									text: button,
+									class: "pull-left",
+									click: (event) => {
+										if (!window.confirm("Are you really sure you want to do this?")) return;
+
+										const spinner = RED.utils.addSpinnerOverlay($(event.target));
+
+										$.ajax({
+											method: "PUT",
+											url: path,
+											data: { script: "load-config-node" },
+											success: function (resp) {
+												spinner.remove();
+												myNotification.close();
+											}
+										});
+									}
+								};
 							} else {
 								console.error("Unknown button", button);
 								return {};
@@ -124,15 +146,21 @@
 			const refreshMsg = `
 			<html>
 				<p>Welcome to Google Cloud Firestore</p>
-				<p>Oops, it looks like your browser didn't load the Firestore nodes 😬</p>
+				<p>Oops, it looks like your browser didn't load all Firestore nodes 😬</p>
 				<p>Please reload your browser 😁</p>
 			</html>`;
 			const restartMsg = `
 			<html>
-				<p>Welcome to Google Cloud Firestore</p>
-				<p>To use this palette of nodes, please restart Node-RED. If you are using FlowFuse, suspend then start the instance.</p>
-				<p>A restart is needed because Node-RED did not load all nodes correctly.</p>
-				<p>Read more about this issue <a href="https://github.com/GogoVega/node-red-contrib-firebase-realtime-database/discussions/50">here</a>.</p>
+				<h3>Welcome to Google Cloud Firestore</h3>
+				<h4>🔄 Action Required</h4>
+				<p>To use this node palette, you need to restart <strong>Node-RED</strong>.</p>
+				<ul>
+					<li>If you are running <strong>FlowFuse</strong>, suspend and then restart the instance.</li>
+				</ul>
+				<p>This step is necessary because Node-RED did not load the config node.</p>
+				<h4>⚠️ Experimental Alternative</h4>
+				<p>You can try loading the config node, but this method is still experimental and may not work in all cases.</p>
+				<p>👉 <a href="https://github.com/GogoVega/node-red-contrib-firebase-realtime-database/discussions/50" target="_blank">Learn more about this issue</a></p>
 			</html>`;
 			const restartAfterUpdateMsg = `
 			<html>
@@ -163,6 +191,7 @@
 					break;
 				case "restart":
 					msg = restartMsg;
+					buttons = ["Load Config Node", "Close"]
 					break;
 				case "restart-update":
 					msg = restartAfterUpdateMsg;

--- a/src/plugins/config-node-checker.ts
+++ b/src/plugins/config-node-checker.ts
@@ -46,7 +46,7 @@ module.exports = function (RED: NodeAPI) {
 		}
 	);
 
-	// Run the Update Script
+	// Run the Update/Load Script
 	RED.httpAdmin.put(
 		"/firebase/firestore/config-node/scripts",
 		RED.auth.needsPermission("firestore-out.write"),
@@ -118,9 +118,12 @@ module.exports = function (RED: NodeAPI) {
 				res.json({ status: "success" });
 			} catch (error) {
 				const msg = error instanceof Error ? error.toString() : (error as Record<"stderr", string>).stderr;
-				const action = req.body.script === "update-dependencies" ? "updating nodes dependencies" : "loading the config node";
+				const action: Record<string, string> = {
+					"update-dependencies": "updating nodes dependencies",
+					"load-config-node": "loading the config node",
+				};
 
-				RED.log.error(`[firestore:plugin]: An error occurred while ${action}: ` + msg);
+				RED.log.error(`[firestore:plugin]: An error occurred while ${action[req.body.script]}: ` + msg);
 
 				res.json({
 					status: "error",


### PR DESCRIPTION
The goal is to avoid the NR limitation: having to restart Node-RED after installing from the Palette Manager.

https://github.com/GogoVega/node-red-contrib-cloud-firestore/blob/1c885ae49ad5979c2423ca57da0446ca38482514/src/plugins/config-node-checker.ts#L79-L95