### PR TITLE
Load UI scripts from Plugins

### DIFF
--- a/build/nodes/firestore-get.html
+++ b/build/nodes/firestore-get.html
@@ -14,10 +14,6 @@
   limitations under the License.
 -->
 
-<!-- Load Scripts -->
-<script type="text/javascript" src="resources/@gogovega/node-red-contrib-cloud-firestore/common.js"></script>
-<script type="text/javascript" src="resources/@gogovega/node-red-contrib-cloud-firestore/constraints.js"></script>
-
 <script type="text/javascript">
 	"use strict";
 

--- a/build/nodes/firestore-in.html
+++ b/build/nodes/firestore-in.html
@@ -14,10 +14,6 @@
   limitations under the License.
 -->
 
-<!-- Load Scripts -->
-<script type="text/javascript" src="resources/@gogovega/node-red-contrib-cloud-firestore/common.js"></script>
-<script type="text/javascript" src="resources/@gogovega/node-red-contrib-cloud-firestore/constraints.js"></script>
-
 <script type="text/javascript">
 	"use strict";
 

--- a/build/nodes/firestore-out.html
+++ b/build/nodes/firestore-out.html
@@ -16,6 +16,7 @@
 
 <!-- Load Scripts -->
 <script type="text/javascript" src="resources/@gogovega/node-red-contrib-cloud-firestore/common.js"></script>
+<script type="text/javascript" src="resources/@gogovega/node-red-contrib-cloud-firestore/constraints.js"></script>
 
 <script type="text/javascript">
 	"use strict";

--- a/build/plugins/config-node-checker.html
+++ b/build/plugins/config-node-checker.html
@@ -14,6 +14,10 @@
   limitations under the License.
 -->
 
+<!-- Load Nodes Scripts -->
+<script type="text/javascript" src="resources/@gogovega/node-red-contrib-cloud-firestore/common.js"></script>
+<script type="text/javascript" src="resources/@gogovega/node-red-contrib-cloud-firestore/constraints.js"></script>
+
 <script type="text/javascript">
 	"use strict";
 


### PR DESCRIPTION
Loads scripts (needed by nodes) from Plugins because Plugins are loaded before Nodes.

The Firestore OUT node is the only one that also loads them in case plugins are not loaded by the editor.