### PR TITLE
Remove the config node module when uninstalling the palette

### DIFF
--- a/build/plugins/config-node-checker.html
+++ b/build/plugins/config-node-checker.html
@@ -269,7 +269,10 @@
 				} else {
 					RED.events.on("flows:loaded", checker);
 				}
-			}
+			},
+			onremove: function () {
+				console.log("[firestore:plugin]: Firestore Config Node Checker stopped");
+			},
 		});
 	})();
 

--- a/build/plugins/tours-runner.html
+++ b/build/plugins/tours-runner.html
@@ -91,7 +91,12 @@
 
 				// Allow the config node checker to run tours
 				plugin.runner = initTourGuide;
-			}
+			},
+			onremove: function () {
+				// Must clean the editor
+				delete plugin.runner;
+				console.log("[firestore:plugin]: Firestore Tours Runner stopped");
+			},
 		};
 
 		RED.plugins.registerPlugin("firestore-tours-runner", plugin);

--- a/src/lib/types/node-red.ts
+++ b/src/lib/types/node-red.ts
@@ -31,4 +31,5 @@ export interface Util {
 export interface Registry {
 	addModule(name: string): Promise<ModuleInfo>;
 	getModuleInfo(name: string): ModuleInfo | null;
+	removeModule(name: string, skipSave?: boolean): { id: string }[];
 }


### PR DESCRIPTION
If a user uninstalls the Firestore Palette and refreshes the browser, the editor will remain stuck while loading because the config node resources are no longer available.

To avoid this hang, when uninstalling the Palette, the config node module will be removed.

Unfortunately, this solution isn't perfect because:
- it won't prevent the Palette from being uninstalled if a config node is still in use
- it doesn't warn the user to delete the remaining config nodes