### PR TITLE
Update the `Publish` workflow

### DIFF
--- a/.github/scripts/update-required-config-node-version.js
+++ b/.github/scripts/update-required-config-node-version.js
@@ -27,7 +27,7 @@ try {
 	console.log("Check if the required Config Node version is up to date...");
 
 	const packageFile = require("../../package.json");
-	const destinationFilePath = join(__dirname, "../", filePath);
+	const destinationFilePath = join(__dirname, "..", "..", filePath);
 
 	if (existsSync(destinationFilePath)) {
 		const destinationFile = readFileSync(destinationFilePath, { encoding: "utf8" });

--- a/.github/scripts/update-required-config-node-version.js
+++ b/.github/scripts/update-required-config-node-version.js
@@ -26,7 +26,7 @@ const versionRegex = /requiredVersion: \[number, number, number\] = \[([0-9], [0
 try {
 	console.log("Check if the required Config Node version is up to date...");
 
-	const packageFile = require("../package.json");
+	const packageFile = require("../../package.json");
 	const destinationFilePath = join(__dirname, "../", filePath);
 
 	if (existsSync(destinationFilePath)) {

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -28,17 +29,16 @@ jobs:
 
       # Ensure the required version is up to date
       - name: Update the Required Config Node version
-        run: node ./scripts/update-required-config-node-version.js
+        run: node ./.github/scripts/update-required-config-node-version.js
 
       - name: Build
         run: npm run build
 
       - name: Publish package to public npm registry
-        uses: JS-DevTools/npm-publish@v3
+        uses: JS-DevTools/npm-publish@v4
         with:
           access: public
           tag: ${{ contains(github.ref, '-beta') && 'beta' || contains(github.ref, '-alpha') && 'alpha' || 'latest' }}
-          token: ${{ secrets.NPM_TOKEN }}
 
   # TODO: Use a webhook because sleep is not ideal
   update-library:


### PR DESCRIPTION
- Move the `update-required-config-node-version` script to `.github` directory
- Use the `OpenID Connect` token